### PR TITLE
path: previous node list representation

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -48,12 +48,53 @@ pub(crate) fn check_edge_path_valid(g: &Graph, path: Vec<(usize, usize)>) -> boo
     true
 }
 
+/// TODO: add documentation
+pub(crate) fn check_previous_node_list_valid(g: &Graph, path: Vec<Option<usize>>) -> bool {
+    // should have an entry for each node in the graph
+    if path.len() != g.num_of_nodes() {
+        return false;
+    }
+
+    // every index in path represents a node
+    // the contents of the index represents a node that can get to it
+    // hence (content, node) should represent an edge
+    for (node_id, maybe_previous_id) in path.iter().enumerate() {
+        if let Some(previous_id) = maybe_previous_id {
+            if !g.is_edge(*previous_id, node_id) {
+                return false;
+            }
+        }
+    }
+
+    true
+}
+
+/// Converts from a list of previous nodes to a node list representation for a given destination
+/// node
+pub(crate) fn node_list_from_prev_node_list(
+    prev_node_list: Vec<Option<usize>>,
+    destination: usize,
+) -> Vec<usize> {
+    let mut node_list = vec![];
+    let mut current = Some(destination);
+
+    while let Some(curr_index) = current {
+        node_list.push(curr_index);
+        current = prev_node_list[curr_index]
+    }
+
+    node_list.reverse();
+    node_list
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{
         path::{check_edge_path_valid, check_node_path_valid},
         tests::undirected_graph,
     };
+
+    use super::node_list_from_prev_node_list;
 
     #[test]
     fn test_path_node_list_valid() {
@@ -73,5 +114,14 @@ mod tests {
             &graph,
             vec![(0, 1), (1, 3), (4, 5), (5, 2)]
         ));
+    }
+
+    #[test]
+    fn test_prev_node_list_to_path_node_list() {
+        let prev_node_list = vec![-1, 0, 1, 2, 2, 0, 5, 0, 5, 8]
+            .into_iter()
+            .map(|v| if v == -1 { None } else { Some(v as usize) })
+            .collect::<Vec<Option<usize>>>();
+        dbg!(node_list_from_prev_node_list(prev_node_list, 9));
     }
 }


### PR DESCRIPTION
In this representation, we have a list with each index corresponding to a node_id (currently graphs have nodes contiguously indexed starting from 0). 

the value of each index in the array specifies the previous node that was visited before the current node. 

e.g. given the following node list path representation [0, 2, 3] i.e. visit node 0 then visit node 2 and finally visit node 3, assuming we have 6 nodes in our system. The prev_node list representation will look as follows: 

index:     0   1  2  3   4    5   6
values: [-1, -1, 0, 2, -1, -1, -1]

since 0 wasn't visited from an already existing node it is set to -1
since 2 was visited from 0 the entry is set to 0
since 3 was visited from 2 the entry is set to 2
