### PR TITLE
refactor: make node label generic

### DIFF
--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -44,17 +44,3 @@ pub(crate) trait Node {
 /// (seen, previous_node)
 #[derive(Clone)]
 pub(crate) struct NodeTrackState(bool, Option<NodeId>);
-
-pub(crate) trait VisitedTracker {
-    /// Use the tracker to determine if a node has been seen
-    fn has_seen(&self, node_id: NodeId) -> bool;
-
-    /// Set the seen status of a particular node to true
-    fn set_seen(&mut self, node_id: NodeId);
-
-    /// Set the previous_node for a given node to some node_id
-    fn set_prev(&mut self, node_id: NodeId, prev_node_id: NodeId);
-
-    /// Converts the tracker state to the prev_node_list path representation
-    fn prev_node_list(&self) -> PrevNodeGraphPath;
-}

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -1,3 +1,4 @@
+use crate::tracker::VisitedTracker;
 use graph_path::PrevNodeGraphPath;
 
 pub(crate) mod graph_path;
@@ -12,12 +13,12 @@ pub(crate) enum GraphType {
     Undirected,
 }
 
-pub(crate) trait Graph {
-    type NodeType: Node;
-    type Trakcer: VisitedTracker;
+pub(crate) trait Graph<T> {
+    type NodeType: Node<T>;
+    type Trakcer: VisitedTracker<T>;
 
     /// Given a node id, return a reference to the concrete node
-    fn node(&self, node_id: usize) -> Option<&Self::NodeType>;
+    fn node(&self, node_id: &T) -> Option<&Self::NodeType>;
 
     /// Optionally returns the total number of nodes in the graph
     /// for static graph that know the exact count for nodes this
@@ -35,12 +36,7 @@ pub(crate) trait Graph {
     fn visited_tracker(&self) -> Self::Trakcer;
 }
 
-pub(crate) trait Node {
+pub(crate) trait Node<T> {
     /// Returns the neighbors for a given node
-    fn neighbors(&self) -> impl Iterator<Item = &NodeId>;
+    fn neighbors(&self) -> impl Iterator<Item = &T>;
 }
-
-/// Holds search information about a given node
-/// (seen, previous_node)
-#[derive(Clone)]
-pub(crate) struct NodeTrackState(bool, Option<NodeId>);

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -38,5 +38,5 @@ pub(crate) trait Graph<T> {
 
 pub(crate) trait Node<T> {
     /// Returns the neighbors for a given node
-    fn neighbors(&self) -> impl Iterator<Item = &T>;
+    fn neighbors(&self) -> impl Iterator<Item = T>;
 }

--- a/src/graph/static_graph.rs
+++ b/src/graph/static_graph.rs
@@ -10,8 +10,8 @@ pub(crate) struct StaticNode {
 }
 
 impl Node<NodeId> for StaticNode {
-    fn neighbors(&self) -> impl Iterator<Item = &NodeId> {
-        self.edges.keys()
+    fn neighbors(&self) -> impl Iterator<Item = NodeId> {
+        self.edges.keys().map(|v| *v)
     }
 }
 

--- a/src/graph/static_graph.rs
+++ b/src/graph/static_graph.rs
@@ -1,16 +1,15 @@
 //! Represents a graph whose nodes and edges are known before hand
+use crate::tracker::StaticTracker;
 use std::collections::BTreeMap;
 
-use crate::graph::{Graph, GraphType, Node, NodeId, NodeTrackState, Weight};
-
-use super::VisitedTracker;
+use crate::graph::{Graph, GraphType, Node, NodeId, Weight};
 
 pub(crate) struct StaticNode {
     index: usize,
     edges: BTreeMap<NodeId, Weight>,
 }
 
-impl Node for StaticNode {
+impl Node<NodeId> for StaticNode {
     fn neighbors(&self) -> impl Iterator<Item = &NodeId> {
         self.edges.keys()
     }
@@ -34,12 +33,12 @@ pub(crate) struct StaticGraph {
     graph_type: GraphType,
 }
 
-impl Graph for StaticGraph {
+impl Graph<NodeId> for StaticGraph {
     type NodeType = StaticNode;
     type Trakcer = StaticTracker;
 
-    fn node(&self, node_id: usize) -> Option<&Self::NodeType> {
-        self.nodes.get(node_id)
+    fn node(&self, node_id: &NodeId) -> Option<&Self::NodeType> {
+        self.nodes.get(*node_id)
     }
 
     fn num_of_nodes(&self) -> Option<usize> {
@@ -68,36 +67,6 @@ impl StaticGraph {
         if self.graph_type == GraphType::Undirected {
             self.nodes[to].add_edge(from, weight);
         }
-    }
-}
-
-pub(crate) struct StaticTracker {
-    state: Vec<NodeTrackState>,
-}
-
-impl StaticTracker {
-    fn new(node_count: usize) -> Self {
-        Self {
-            state: vec![NodeTrackState(false, None); node_count],
-        }
-    }
-}
-
-impl VisitedTracker for StaticTracker {
-    fn has_seen(&self, node_id: NodeId) -> bool {
-        self.state[node_id].0
-    }
-
-    fn set_seen(&mut self, node_id: NodeId) {
-        self.state[node_id].0 = true;
-    }
-
-    fn set_prev(&mut self, node_id: NodeId, prev_node_id: NodeId) {
-        self.state[node_id].1 = Some(prev_node_id);
-    }
-
-    fn prev_node_list(&self) -> Vec<Option<NodeId>> {
-        self.state.iter().map(|v| v.1).collect()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use std::{
 mod applications;
 mod graph;
 mod search;
+mod tracker;
 
 mod bfs;
 mod clustering;

--- a/src/search/bfs.rs
+++ b/src/search/bfs.rs
@@ -1,20 +1,21 @@
 use std::collections::VecDeque;
 
-use crate::graph::{graph_path::PrevNodeGraphPath, Graph, Node, VisitedTracker};
+use crate::graph::{graph_path::PrevNodeGraphPath, Graph, Node};
+use crate::tracker::VisitedTracker;
 
-pub(crate) fn bfs<G: Graph>(graph: &G, start_node: usize) -> PrevNodeGraphPath {
+pub(crate) fn bfs<T: Clone, G: Graph<T>>(graph: &G, start_node: T) -> PrevNodeGraphPath {
     let mut visited_tracker = graph.visited_tracker();
 
     // init queue and set start_node to seen
+    visited_tracker.set_seen(&start_node);
     let mut queue = VecDeque::from([start_node]);
-    visited_tracker.set_seen(start_node);
 
     while let Some(node_id) = queue.pop_front() {
-        for neighbor in graph.node(node_id).unwrap().neighbors() {
-            if !visited_tracker.has_seen(*neighbor) {
-                visited_tracker.set_seen(*neighbor);
-                visited_tracker.set_prev(*neighbor, node_id);
-                queue.push_back(*neighbor);
+        for neighbor in graph.node(&node_id).unwrap().neighbors() {
+            if !visited_tracker.has_seen(neighbor) {
+                visited_tracker.set_seen(neighbor);
+                visited_tracker.set_prev(neighbor, &node_id);
+                queue.push_back(neighbor.clone());
             }
         }
     }

--- a/src/search/bfs.rs
+++ b/src/search/bfs.rs
@@ -12,10 +12,10 @@ pub(crate) fn bfs<T: Clone, G: Graph<T>>(graph: &G, start_node: T) -> PrevNodeGr
 
     while let Some(node_id) = queue.pop_front() {
         for neighbor in graph.node(&node_id).unwrap().neighbors() {
-            if !visited_tracker.has_seen(neighbor) {
-                visited_tracker.set_seen(neighbor);
-                visited_tracker.set_prev(neighbor, &node_id);
-                queue.push_back(neighbor.clone());
+            if !visited_tracker.has_seen(&neighbor) {
+                visited_tracker.set_seen(&neighbor);
+                visited_tracker.set_prev(&neighbor, &node_id);
+                queue.push_back(neighbor);
             }
         }
     }

--- a/src/search/dfs.rs
+++ b/src/search/dfs.rs
@@ -1,18 +1,18 @@
-use crate::graph::{graph_path::PrevNodeGraphPath, Graph, Node, NodeId, VisitedTracker};
+use crate::graph::{graph_path::PrevNodeGraphPath, Graph, Node, NodeId};
+use crate::tracker::VisitedTracker;
 
-pub(crate) fn dfs<G: Graph>(graph: &G, start_node: NodeId) -> PrevNodeGraphPath {
+pub(crate) fn dfs<T: Clone, G: Graph<T>>(graph: &G, start_node: T) -> PrevNodeGraphPath {
     let mut stack = vec![start_node];
     let mut visited_tracker = graph.visited_tracker();
 
     while let Some(node_id) = stack.pop() {
-        if !visited_tracker.has_seen(node_id) {
-            dbg!(node_id);
-            visited_tracker.set_seen(node_id);
-            let current_node = graph.node(node_id).unwrap();
+        if !visited_tracker.has_seen(&node_id) {
+            visited_tracker.set_seen(&node_id);
+            let current_node = graph.node(&node_id).unwrap();
             for neighbor in current_node.neighbors() {
-                if !visited_tracker.has_seen(*neighbor) {
-                    visited_tracker.set_prev(*neighbor, node_id);
-                    stack.push(*neighbor);
+                if !visited_tracker.has_seen(neighbor) {
+                    visited_tracker.set_prev(neighbor, &node_id);
+                    stack.push(neighbor.clone());
                 }
             }
         }

--- a/src/search/dfs.rs
+++ b/src/search/dfs.rs
@@ -10,9 +10,9 @@ pub(crate) fn dfs<T: Clone, G: Graph<T>>(graph: &G, start_node: T) -> PrevNodeGr
             visited_tracker.set_seen(&node_id);
             let current_node = graph.node(&node_id).unwrap();
             for neighbor in current_node.neighbors() {
-                if !visited_tracker.has_seen(neighbor) {
-                    visited_tracker.set_prev(neighbor, &node_id);
-                    stack.push(neighbor.clone());
+                if !visited_tracker.has_seen(&neighbor) {
+                    visited_tracker.set_prev(&neighbor, &node_id);
+                    stack.push(neighbor);
                 }
             }
         }

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -1,0 +1,15 @@
+use crate::graph::graph_path::PrevNodeGraphPath;
+
+pub(crate) trait VisitedTracker<T> {
+    /// Use the tracker to determine if a node has been seen
+    fn has_seen(&self, node_label: T) -> bool;
+
+    /// Set the seen status of a particular node to true
+    fn set_seen(&mut self, node_label: T);
+
+    /// Set the previous_node for a given node to some node_id
+    fn set_prev(&mut self, node_label: T, prev_node_label: T);
+
+    /// Converts the tracker state to the prev_node_list path representation
+    fn prev_node_list(&self) -> PrevNodeGraphPath;
+}

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -1,15 +1,50 @@
-use crate::graph::graph_path::PrevNodeGraphPath;
+use crate::graph::{graph_path::PrevNodeGraphPath, NodeId};
 
 pub(crate) trait VisitedTracker<T> {
     /// Use the tracker to determine if a node has been seen
-    fn has_seen(&self, node_label: T) -> bool;
+    fn has_seen(&self, node_label: &T) -> bool;
 
     /// Set the seen status of a particular node to true
-    fn set_seen(&mut self, node_label: T);
+    fn set_seen(&mut self, node_label: &T);
 
     /// Set the previous_node for a given node to some node_id
-    fn set_prev(&mut self, node_label: T, prev_node_label: T);
+    fn set_prev(&mut self, node_label: &T, prev_node_label: &T);
 
     /// Converts the tracker state to the prev_node_list path representation
     fn prev_node_list(&self) -> PrevNodeGraphPath;
+}
+
+/// Holds search information about a given node
+/// (seen, previous_node)
+#[derive(Clone)]
+pub(crate) struct NodeTrackState(bool, Option<NodeId>);
+
+pub(crate) struct StaticTracker {
+    state: Vec<NodeTrackState>,
+}
+
+impl StaticTracker {
+    pub(crate) fn new(node_count: usize) -> Self {
+        Self {
+            state: vec![NodeTrackState(false, None); node_count],
+        }
+    }
+}
+
+impl VisitedTracker<NodeId> for StaticTracker {
+    fn has_seen(&self, node_id: &NodeId) -> bool {
+        self.state[*node_id].0
+    }
+
+    fn set_seen(&mut self, node_id: &NodeId) {
+        self.state[*node_id].0 = true;
+    }
+
+    fn set_prev(&mut self, node_id: &NodeId, prev_node_id: &NodeId) {
+        self.state[*node_id].1 = Some(*prev_node_id);
+    }
+
+    fn prev_node_list(&self) -> Vec<Option<NodeId>> {
+        self.state.iter().map(|v| v.1).collect()
+    }
 }


### PR DESCRIPTION
dynamic graphs might not necessarily require the node labels to be of type usize, this pr makes the label generic